### PR TITLE
Bump optparse-applicative upper bound

### DIFF
--- a/elm-make.cabal
+++ b/elm-make.cabal
@@ -55,5 +55,5 @@ Executable elm-make
         elm-package,
         filepath,
         mtl,
-        optparse-applicative >=0.10 && <0.11,
+        optparse-applicative >=0.10 && <0.12,
         text


### PR DESCRIPTION
Works fine with the new version