### PR TITLE
Expose Elm object with a string so it survives obfuscation.

### DIFF
--- a/src/Generate.hs
+++ b/src/Generate.hs
@@ -67,7 +67,7 @@ generate cachePath dependencies natives moduleIDs outputFile =
 
 header :: Text.Text
 header =
-    "var Elm = Elm || { Native: {} };"
+    "var Elm = ((typeof module !== 'undefined' && module.exports) ? module.exports : this)['Elm'] = { Native: {} }; "
 
 
 errorNotOneModule :: [ModuleID] -> String


### PR DESCRIPTION
1. Remove the `Elm || { ... }`. This is a holdover from elm-runtime.js days. Now all Elm stuff should be in one js file and if `Elm` was already defined, bad things could happen (like mixing libraries from different versions of core).
2. Expose `Elm` object as `window['Elm']` (in browser) or `module.exports['Elm']` (in node).