### PR TITLE
Update optparse upper bound

### DIFF
--- a/elm-make.cabal
+++ b/elm-make.cabal
@@ -66,5 +66,5 @@ Executable elm-make
         elm-package,
         filepath,
         mtl,
-        optparse-applicative >=0.10 && <0.11,
+        optparse-applicative >=0.10 && <0.12,
         text


### PR DESCRIPTION
I tested this, and everything compiles and appears to parse options correctly.
This allows elm-make to work with base-4.8, which should make building with other packages a lot easier. In particular, I think this might help with getting elm built with GHCJS.
Also, this should resolve the issues with Stackage that arose a while back.