### PR TITLE
0.11.0 is minimum optparse version

### DIFF
--- a/elm-make.cabal
+++ b/elm-make.cabal
@@ -67,5 +67,5 @@ Executable elm-make
         elm-package,
         filepath,
         mtl >= 2.2.1 && < 3,
-        optparse-applicative >=0.10 && <0.12,
+        optparse-applicative >=0.11 && <0.12,
         text


### PR DESCRIPTION
For some reason, optparse 0.10.0 has an `eitherReader` which takes two arguments:
https://hackage.haskell.org/package/optparse-applicative-0.10.0/docs/Options-Applicative-Builder.html#v:eitherReader

Which causes this error compiling elm-make:
```
$ cabal install
Resolving dependencies...
Notice: installing into a sandbox located at
/Users/laszlopandy/dev/elm-compiler/.cabal-sandbox
Configuring elm-make-0.1.2...
Building elm-make-0.1.2...
Failed to install elm-make-0.1.2
Last 10 lines of the build log ( /Users/laszlopandy/dev/elm-compiler/.cabal-sandbox/logs/elm-make-0.1.2.log ):
        (bound at src/Arguments.hs:128:1)
    Probable cause: ‘Opt.eitherReader’ is applied to too few arguments
    In the expression: Opt.eitherReader reader
    In the expression:
      let
        reader arg
          = case fromString arg of {
              Just a -> ...
              Nothing -> ... }
      in Opt.eitherReader reader
cabal: Error: some packages failed to install:
elm-make-0.1.2 failed during the building phase. The exception was:
ExitFailure 1

```