### PR TITLE
All file reading and writing explicitly uses UTF-8

### DIFF
--- a/src/Build.hs
+++ b/src/Build.hs
@@ -141,7 +141,7 @@ buildManager env state =
             Right (interface, js) ->
               do  let cache = cachePath env
                   File.writeBinary (Path.toInterface cache moduleID) interface
-                  writeFile (Path.toObjectFile cache moduleID) js
+                  File.writeStringUtf8 (Path.toObjectFile cache moduleID) js
                   Chan.writeChan (reportChan env) (Report.Complete moduleID)
                   buildManager env (registerSuccess env state moduleID interface threadId)
 
@@ -241,7 +241,7 @@ buildModule env interfaces (moduleID, location) =
     ifaces = Map.mapKeysMonotonic TMP.moduleName interfaces
     isRoot = Set.member moduleID (publicModules env)
   in
-  do  source <- readFile path
+  do  source <- File.readStringUtf8 path
       let (dealiaser, warnings, rawResult) =
             Compiler.compile user project isRoot source ifaces
 

--- a/src/CrawlPackage.hs
+++ b/src/CrawlPackage.hs
@@ -15,6 +15,7 @@ import qualified Elm.Package.Name as Pkg
 import qualified Elm.Package.Paths as Path
 import qualified Elm.Package.Solution as Solution
 import qualified Elm.Package.Version as V
+import qualified Utils.File as File
 import qualified TheMasterPlan as TMP
 import TheMasterPlan ( PackageSummary(..), PackageData(..) )
 
@@ -180,7 +181,7 @@ readPackageData
     -> FilePath
     -> m (Module.Name, (PackageData, [(Module.Name, Maybe Module.Name)]))
 readPackageData pkgName maybeName filePath =
-  do  sourceCode <- liftIO (readFile filePath)
+  do  sourceCode <- liftIO (File.readStringUtf8 filePath)
 
       (name, rawDeps) <-
           case Compiler.parseDependencies sourceCode of

--- a/src/Generate.hs
+++ b/src/Generate.hs
@@ -12,7 +12,7 @@ import qualified Data.Text.Lazy.IO as Text
 import qualified Data.Tree as Tree
 import System.Directory ( createDirectoryIfMissing )
 import System.FilePath ( dropFileName, takeExtension )
-import System.IO ( IOMode(WriteMode), withFile )
+import System.IO ( IOMode(WriteMode) )
 import qualified Text.Blaze as Blaze
 import Text.Blaze.Html5 ((!))
 import qualified Text.Blaze.Html5 as H
@@ -22,6 +22,7 @@ import qualified Text.Blaze.Renderer.Text as Blaze
 import Elm.Utils ((|>))
 import qualified Elm.Compiler.Module as Module
 import qualified Path
+import qualified Utils.File as File
 import TheMasterPlan ( ModuleID(ModuleID), Location )
 
 
@@ -49,18 +50,18 @@ generate cachePath dependencies natives moduleIDs outputFile =
           case moduleIDs of
             [ModuleID moduleName _] ->
               liftIO $
-                do  js <- mapM Text.readFile objectFiles
-                    Text.writeFile outputFile (html (Text.concat (header:js)) moduleName)
+                do  js <- mapM File.lazyReadTextUtf8 objectFiles
+                    File.lazyWriteTextUtf8 outputFile (html (Text.concat (header:js)) moduleName)
 
             _ ->
               throwError (errorNotOneModule moduleIDs)
 
         _ ->
           liftIO $
-          withFile outputFile WriteMode $ \handle ->
+          File.withFileUtf8 outputFile WriteMode $ \handle ->
               do  Text.hPutStrLn handle header
                   forM_ objectFiles $ \jsFile ->
-                      Text.hPutStrLn handle =<< Text.readFile jsFile
+                      Text.hPutStrLn handle =<< File.lazyReadTextUtf8 jsFile
 
       liftIO (putStrLn ("Successfully generated " ++ outputFile))
 

--- a/src/Utils/File.hs
+++ b/src/Utils/File.hs
@@ -4,6 +4,7 @@ module Utils.File where
 import Control.Monad.Except (MonadError, throwError, MonadIO, liftIO)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Binary as Binary
+import GHC.IO.Exception ( IOErrorType(InvalidArgument) )
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FilePath (dropFileName)
 import System.IO (utf8, hPutStr, hSetEncoding, withBinaryFile, withFile, Handle, IOMode(ReadMode, WriteMode))
@@ -71,8 +72,8 @@ readTextUtf8 name =
 
 convertUtf8Error :: FilePath -> IOError -> IOError
 convertUtf8Error filepath e =
-  case show (ioeGetErrorType e) of
-    "invalid argument" -> utf8Error
+  case ioeGetErrorType e of
+    InvalidArgument -> utf8Error
     _ -> e
   where
     errorMessage = "Bad encoding; the file must be valid UTF-8"

--- a/src/Utils/File.hs
+++ b/src/Utils/File.hs
@@ -6,7 +6,13 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Binary as Binary
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FilePath (dropFileName)
-import System.IO (withBinaryFile, IOMode(WriteMode))
+import System.IO (utf8, hPutStr, hSetEncoding, withBinaryFile, withFile, Handle, IOMode(ReadMode, WriteMode))
+import System.IO.Error (IOError, ioeGetErrorType, annotateIOError, modifyIOError)
+
+import qualified Data.Text as Text
+import qualified Data.Text.IO as TextIO
+import qualified Data.Text.Lazy as LazyText
+import qualified Data.Text.Lazy.IO as LazyTextIO
 
 
 writeBinary :: (Binary.Binary a) => FilePath -> a -> IO ()
@@ -41,3 +47,58 @@ errorCorrupted filePath =
 errorNotFound :: FilePath -> String
 errorNotFound filePath =
     "Unable to find file " ++ filePath ++ " for deserialization!"
+
+
+{-|
+  readStringUtf8 converts Text to String instead of reading
+  a String directly because System.IO.hGetContents is lazy,
+  and with lazy IO, decoding exception cannot be caught.
+  By using the strict Text type, we force any decoding
+  exceptions to be thrown so we can show our UTF-8 message.
+-}
+readStringUtf8 :: FilePath -> IO String
+readStringUtf8 name =
+  readTextUtf8 name >>= (return . Text.unpack)
+
+
+readTextUtf8 :: FilePath -> IO Text.Text
+readTextUtf8 name =
+  let action handle =
+        modifyIOError (convertUtf8Error name) (TextIO.hGetContents handle)
+  in
+    withFileUtf8 name ReadMode action
+
+
+convertUtf8Error :: FilePath -> IOError -> IOError
+convertUtf8Error filepath e =
+  case show (ioeGetErrorType e) of
+    "invalid argument" -> utf8Error
+    _ -> e
+  where
+    errorMessage = "Bad encoding; the file must be valid UTF-8"
+    utf8Error = annotateIOError (userError errorMessage) "" Nothing (Just filepath)
+
+
+{-|
+  It is okay to use lazy IO for files created by Elm (ie. object files),
+  because we know they will have the correct encoding.
+  For user provided files, use readStringUtf8 or readTextUtf8!
+-}
+lazyReadTextUtf8 :: FilePath -> IO LazyText.Text
+lazyReadTextUtf8 name =
+  withFileUtf8 name ReadMode LazyTextIO.hGetContents
+
+
+writeStringUtf8 :: FilePath -> String -> IO ()
+writeStringUtf8 f str =
+  withFileUtf8 f WriteMode (\handle -> hPutStr handle str)
+
+
+lazyWriteTextUtf8 :: FilePath -> LazyText.Text -> IO ()
+lazyWriteTextUtf8 f txt =
+  withFileUtf8 f WriteMode (\handle -> LazyTextIO.hPutStr handle txt)
+
+
+withFileUtf8 :: FilePath -> IOMode -> (Handle -> IO a) -> IO a
+withFileUtf8 f mode action =
+  withFile f mode (\handle -> hSetEncoding handle utf8 >> action handle)


### PR DESCRIPTION
Changes two things:
 * All reads and writes go through utility functions which explicitly force UTF-8 instead of using the system's default encoding.
 * Catches the decoding exception if someone isn't using UTF-8:
  * `hGetContents: invalid argument (invalid byte sequence)`,
  * and changes it to read: `Bad encoding; the file must be valid UTF-8`

People share Elm files on GitHub, and elsewhere. So even if you have a strange system using a strange locale, we should still use UTF-8 everywhere to avoid compatibility issues.

I believe this will fix elm-lang/elm-compiler#914, however I could not reproduce the bug on my machine so I cannot say for sure. More testing is needed with a custom build of this branch.