### PR TITLE
Avoid name conflicts, refactor out TheMasterPlan.CanonicalModule

### DIFF
--- a/src/BuildManager.hs
+++ b/src/BuildManager.hs
@@ -117,7 +117,7 @@ data Error
     = BadFlags
     | CompilerErrors FilePath String [Compiler.Error]
     | CorruptedArtifact FilePath
-    | Cycle [TMP.CanonicalModule]
+    | Cycle [Module.CanonicalName]
     | PackageProblem String
     | MissingPackage Pkg.Name
     | ModuleNotFound Module.Name (Maybe Module.Name)

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -8,17 +8,17 @@ import Elm.Package as Pkg
 import qualified TheMasterPlan as TMP
 
 
-toInterface :: FilePath -> TMP.CanonicalModule -> FilePath
-toInterface root (TMP.CanonicalModule package (Module.Name names)) =
-    root </> inPackage package (List.intercalate "-" names <.> "elmi")
+toInterface :: FilePath -> Module.CanonicalName -> FilePath
+toInterface root (Module.CanonicalName pnm pvr (Module.Name names)) =
+    root </> inPackage (pnm, pvr) (List.intercalate "-" names <.> "elmi")
 
 
-toObjectFile :: FilePath -> TMP.CanonicalModule -> FilePath
-toObjectFile root (TMP.CanonicalModule package (Module.Name names)) =
-    root </> inPackage package (List.intercalate "-" names <.> "elmo")
+toObjectFile :: FilePath -> Module.CanonicalName -> FilePath
+toObjectFile root (Module.CanonicalName pnm pvr (Module.Name names)) =
+    root </> inPackage (pnm, pvr) (List.intercalate "-" names <.> "elmo")
 
 
-toPackageCacheFile :: FilePath -> TMP.Package -> FilePath
+toPackageCacheFile :: FilePath -> Pkg.Package -> FilePath
 toPackageCacheFile root pkg =
     root </> inPackage pkg "graph.dat"
 
@@ -28,6 +28,6 @@ toSource (TMP.Location relativePath _package) =
     relativePath
 
 
-inPackage :: TMP.Package -> FilePath -> FilePath
+inPackage :: Pkg.Package -> FilePath -> FilePath
 inPackage (name, version) relativePath =
     Pkg.toFilePath name </> Pkg.versionToString version </> relativePath

--- a/src/Pipeline/Compile.hs
+++ b/src/Pipeline/Compile.hs
@@ -259,7 +259,6 @@ buildModule env interfaces (modul, location) =
   let
     packageName = Module.canonPkg modul
     path = Path.toSource location
-    ifaces = Map.mapKeys (\cmod -> error "Make CanonicalName" ) interfaces
     isRoot = Set.member modul (modulesForGeneration env)
     isExposed = Set.member modul (exposedModules env)
     importDict =
@@ -274,7 +273,7 @@ buildModule env interfaces (modul, location) =
             Compiler.Context packageName isRoot isExposed importDict
 
       let (dealiaser, warnings, rawResult) =
-            Compiler.compile context source ifaces
+            Compiler.compile context source interfaces
 
       threadId <- myThreadId
       let result =

--- a/src/Pipeline/Compile.hs
+++ b/src/Pipeline/Compile.hs
@@ -29,6 +29,7 @@ data Env = Env
     , resultChan :: Chan.Chan Result
     , reportChan :: Chan.Chan Report.Message
     , docsChan :: Chan.Chan [Docs.Documentation]
+    , dependencies :: Map.Map CanonicalModule [CanonicalModule]
     , reverseDependencies :: Map.Map CanonicalModule [CanonicalModule]
     , cachePath :: FilePath
     , exposedModules :: Set.Set CanonicalModule
@@ -69,6 +70,7 @@ initEnv numProcessors cachePath exposedModules modulesForGeneration dependencies
         , resultChan = resultChan
         , reportChan = reportChan
         , docsChan = docsChan
+        , dependencies = dependencies
         , reverseDependencies = reverseGraph dependencies
         , cachePath = cachePath
         , exposedModules = exposedModules
@@ -257,14 +259,19 @@ buildModule env interfaces (modul, location) =
   let
     packageName = fst (TMP.package modul)
     path = Path.toSource location
-    ifaces = Map.mapKeys TMP.name interfaces
+    ifaces = Map.mapKeys (\cmod -> error "Make CanonicalName" ) interfaces
     isRoot = Set.member modul (modulesForGeneration env)
     isExposed = Set.member modul (exposedModules env)
+    importDict =
+      case Map.lookup modul (dependencies env) of
+        Just imported ->
+          Map.fromList $
+            map (\m -> ( TMP.name m, fst $ TMP.package m) ) imported
   in
   do  source <- readFile path
 
       let context =
-            Compiler.Context packageName isRoot isExposed
+            Compiler.Context packageName isRoot isExposed importDict
 
       let (dealiaser, warnings, rawResult) =
             Compiler.compile context source ifaces

--- a/src/Pipeline/Crawl/Package.hs
+++ b/src/Pipeline/Crawl/Package.hs
@@ -188,7 +188,7 @@ readPackageData pkgName maybeName filePath =
       checkName filePath name maybeName
 
       let deps =
-            if pkgName == TMP.core
+            if pkgName == Pkg.coreName
               then rawDeps
               else Module.defaultImports ++ rawDeps
 

--- a/src/Pipeline/Generate.hs
+++ b/src/Pipeline/Generate.hs
@@ -26,7 +26,7 @@ import qualified Text.Blaze.Renderer.Text as Blaze
 
 import qualified BuildManager as BM
 import qualified Path
-import TheMasterPlan ( CanonicalModule(CanonicalModule), Location )
+import TheMasterPlan ( Location )
 import qualified Utils.File as File
 
 
@@ -45,9 +45,9 @@ docs docsList path =
 
 generate
     :: BM.Config
-    -> Map.Map CanonicalModule [CanonicalModule]
-    -> Map.Map CanonicalModule Location
-    -> [CanonicalModule]
+    -> Map.Map Module.CanonicalName [Module.CanonicalName]
+    -> Map.Map Module.CanonicalName Location
+    -> [Module.CanonicalName]
     -> BM.Task ()
 
 generate _config _dependencies _natives [] =
@@ -65,7 +65,7 @@ generate config dependencies natives rootModules =
         BM.Html outputFile ->
             liftIO $
               do  js <- mapM File.readTextUtf8 objectFiles
-                  let (Just (CanonicalModule _ moduleName)) = Maybe.listToMaybe rootModules
+                  let (Just (Module.CanonicalName _ _ moduleName)) = Maybe.listToMaybe rootModules
                   let outputText = html (Text.concat (header:js)) moduleName
                   LazyText.writeFile outputFile outputText
 
@@ -86,9 +86,9 @@ header =
 
 setupNodes
     :: FilePath
-    -> Map.Map CanonicalModule [CanonicalModule]
-    -> Map.Map CanonicalModule Location
-    -> [(FilePath, CanonicalModule, [CanonicalModule])]
+    -> Map.Map Module.CanonicalName [Module.CanonicalName]
+    -> Map.Map Module.CanonicalName Location
+    -> [(FilePath, Module.CanonicalName, [Module.CanonicalName])]
 setupNodes cachePath dependencies natives =
     let nativeNodes =
             Map.toList natives
@@ -102,8 +102,8 @@ setupNodes cachePath dependencies natives =
 
 
 getReachableObjectFiles
-    :: [CanonicalModule]
-    -> [(FilePath, CanonicalModule, [CanonicalModule])]
+    :: [Module.CanonicalName]
+    -> [(FilePath, Module.CanonicalName, [Module.CanonicalName])]
     -> [FilePath]
 getReachableObjectFiles moduleNames nodes =
     let (dependencyGraph, vertexToKey, keyToVertex) =


### PR DESCRIPTION
Adjust elm-make to fit with this [elm-compiler PR](https://github.com/elm-lang/elm-compiler/pull/1036)

We replace the type `TheMasterPlan.CanonicalModule` with `Elm.Compiler.Module.CanonicalName`. Along with this, we've moved the `Package` type from TheMasterPlan into Elm.Package.

We now give `Elm.Compiler.Compile` an interface dictionary with `Module.CanonicalName` keys, and have added a mapping from imported module names to package names to the `Context` given to the compiler. 