### PR TITLE
Do a separate isTerminal checking for stdout and stderr.

### DIFF
--- a/src/BuildManager.hs
+++ b/src/BuildManager.hs
@@ -163,8 +163,8 @@ printError :: Error -> IO ()
 printError err =
   case err of
     CompilerErrors path source errors ->
-        do  isTerminal <- Report.checkIsTerminal
-            mapM_ (Report.printError isTerminal Compiler.dummyLocalizer path source) errors
+        do  errIsTerminal <- Report.checkIfErrIsTerminal
+            mapM_ (Report.printError errIsTerminal Compiler.dummyLocalizer path source) errors
 
     CorruptedArtifact filePath ->
         hPutStrLn stderr $
@@ -307,4 +307,3 @@ drawCycle modules =
         "  └─────┘"
   in
     unlines (topLine ++ List.intercalate midLine (map line modules) ++ [ bottomLine ])
-


### PR DESCRIPTION
I think having a separate isTerminal checking for stdout and stderr is necessary.
One use case for this is when running elm-make from nodejs, we can choose to ignore/pipe stdout, but not the stderr in order to keep the ansi color on the compiler error message, e.g.: 
```js
spawn('elm-make', args, {stdio: ['ignore', 'ignore', process.stderr]})
```

If we only check for stdout, in the above scenario, the compiler error message will be displayed without the ansi color.

I believe this PR will also solve this issue #70 