### PR TITLE
make Elm variable available on window scope.

### DIFF
--- a/src/Pipeline/Generate.hs
+++ b/src/Pipeline/Generate.hs
@@ -186,7 +186,7 @@ createFooter debugMode canonicalInterfaces rootModules =
         (List.sort (map TMP.simplifyModuleName rootModules))
   in
     Text.pack $
-      "var Elm = {};\n"
+      "this.Elm = {};\n"
       ++ unlines exportChunks
       ++ footerClose
 


### PR DESCRIPTION
# Heyo Evan

I was trying to use Elm in an Electron app and I ran into a weird error where the `Elm` variable was not defined.

I followed the tutorial at https://guide.elm-lang.org/interop/javascript.html like a noob.

Changing the generated file from `var Elm = {}` to `this.Elm = {}` gave me access to the variable, and my problems were resolved.

Likely, I goofed something up, but it's possible I finally made a contribution to Elm, and "wrote my first line" of Haskell code.

I'll attach a link to the repo so you can easily replicate the error.