### PR TITLE
Add incorrectly named files as potential problem for ModuleNotFound e…

### DIFF
--- a/src/BuildManager.hs
+++ b/src/BuildManager.hs
@@ -200,6 +200,8 @@ printError err =
           ++ "Potential problems could be:\n"
           ++ "  * Misspelled the module name\n"
           ++ "  * Need to add a source directory or new dependency to " ++ Path.description
+          ++ "\n"
+          ++ "  * File name does not match the module name"
 
     ModuleDuplicates name maybeParent filePaths pkgs ->
         let


### PR DESCRIPTION
…rror

This will help debug elm-make error when importing a module MyModule and the filename isn't MyModule.elm

Example of the current error where this addition might help:
```
elm-css src/main.elm
I cannot find module 'MyModule'.

Module 'Main' is trying to import it.

Potential problems could be:
  * Misspelled the module name
  * Need to add a source directory or new dependency to elm-package.json
( * File name does not match the module name )
```
