### PR TITLE
GHC option: Enable rtsopts

### DIFF
--- a/elm-make.cabal
+++ b/elm-make.cabal
@@ -31,7 +31,7 @@ source-repository head
 Executable elm-make
 
     ghc-options:
-        -threaded -O2 -W
+        -threaded -O2 -W -rtsopts
 
     hs-source-dirs:
         src


### PR DESCRIPTION
Enabling `rtsopts` allows the user to use haskell runtime [flags](https://downloads.haskell.org/~ghc/7.4.1/docs/html/users_guide/runtime-control.html) to configure cpu and memory usage. This fixes #164 and enables to configure `elm-make` for different environments without forking it.